### PR TITLE
Get pages from archive

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     safe_yaml (1.0.4)
-    scraped_page_archive (0.3.1)
+    scraped_page_archive (0.4.1)
       git (~> 1.3.0)
       vcr-archive (~> 0.3.0)
     slop (3.6.0)

--- a/scraper.rb
+++ b/scraper.rb
@@ -14,8 +14,10 @@ OpenURI::Cache.cache_path = '.cache'
 
 require 'scraped_page_archive/open-uri'
 
+ARCHIVE = ScrapedPageArchive.new
+
 def noko_for(url)
-  Nokogiri::HTML(open(url).read) 
+  Nokogiri::HTML(ARCHIVE.open_from_archive(url).read)
 end
 
 def date_from(str)


### PR DESCRIPTION
Uses the changes from https://github.com/everypolitician/scraped_page_archive/pull/23 to read pages from the archive rather than the live site.

In my testing this brings the runtime down to about 15 seconds, compared to ~8 hours that it takes on morph.
